### PR TITLE
Fix uppercase snapshot images causing crashes

### DIFF
--- a/exporter.js
+++ b/exporter.js
@@ -788,7 +788,7 @@
         for (let i = 0; i < allSnaps.length; i++) {
             const shortCode = allSnaps[i];
             status.textContent = "Downloading snaps... (" + i + ")";
-            await downloadAndStoreSnap(shortCode);
+            await downloadAndStoreSnap(shortCode.toLowerCase());
         }
     };
     const saveSnapByShortcode = async (shortCode) => {

--- a/exporter.ts
+++ b/exporter.ts
@@ -937,7 +937,7 @@ import { ZodInfer } from "./types";
         for (let i = 0; i < allSnaps.length; i++) {
             const shortCode = allSnaps[i]
             status.textContent = "Downloading snaps... (" + i + ")"
-            await downloadAndStoreSnap(shortCode)
+            await downloadAndStoreSnap(shortCode.toLowerCase());
         }
     }
     const saveSnapByShortcode = async (shortCode: string) => {


### PR DESCRIPTION
For some reason my Manyland account had an all-uppercase snapshot name serverside- the code should now be able to handle this type of discrepancy.